### PR TITLE
Handle the `$path` when it is a valid url.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "type": "library",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.4 || ^8.3",
         "ext-json": "*",
         "laravel/framework": "^7.0 || ^8.0 || ^9.0 || ^10.0",
         "guzzlehttp/guzzle": "^7.0",

--- a/src/Requests/PendingRequest.php
+++ b/src/Requests/PendingRequest.php
@@ -114,15 +114,23 @@ class PendingRequest extends HttpPendingRequest
     }
 
     /**
+     * @param $url
+     * @return bool
+     */
+    private function isValidUrl($url): bool
+    {
+        $pattern = '/^.+?\..+$/';
+        return preg_match($pattern, $url) != false;
+    }
+
+    /**
      * @param  null|string  $path
      * @return string
      */
     private function fullUrl(?string $path): string
     {
         $baseUrl = UrlGenerator::baseUrl($this->domain);
-
         $servicePath = $this->service;
-
         if (Str::endsWith($baseUrl, '/')) {
             $baseUrl = Str::substr($baseUrl, 0, -1);
         }
@@ -131,13 +139,11 @@ class PendingRequest extends HttpPendingRequest
             $servicePath = Str::substr($baseUrl, 1);
         }
 
-        if (Str::startsWith($path, '/')) {
-            $finalPath = Str::substr($path, 1);
-        } else {
-            $finalPath = $path;
-        }
+        $finalPath = Str::startsWith($path, '/') ? Str::substr($path, 1) : $path;
 
-        return $baseUrl.($servicePath === '' ? $servicePath : '/'.$servicePath).'/'.$finalPath;
+        $prefix = $baseUrl . ($servicePath === '' ? $servicePath : '/' . $servicePath);
+
+        return $this->isValidUrl($path) ? $finalPath : $prefix . '/' . $finalPath;
     }
 
     private function respond($url, $data, $method)

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -7,10 +7,10 @@ use InvalidArgumentException;
 class UrlGenerator
 {
     /**
-     * @param  string|null  $baseUrl
-     * @return string
+     * @param string|null $baseUrl
+     * @return string|null
      */
-    public static function baseUrl(?string $baseUrl): string
+    public static function baseUrl(?string $baseUrl): string|null
     {
         return $baseUrl ?: config('proxy.base_url');
     }


### PR DESCRIPTION
Prevent the proxy from adding a base_url prefix if the $path is a valid URL by its own